### PR TITLE
Update Terraform AWS resources to current naming

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -1,4 +1,4 @@
-resource "aws_alb_target_group" "default" {
+resource "aws_lb_target_group" "default" {
   name        = local.name
   port        = 8080
   protocol    = "HTTP"
@@ -8,19 +8,19 @@ resource "aws_alb_target_group" "default" {
   deregistration_delay = 0
 }
 
-resource "aws_alb" "default" {
+resource "aws_lb" "default" {
   name            = local.name
   subnets         = aws_subnet.public[*].id
   security_groups = [aws_security_group.alb.id]
 }
 
-resource "aws_alb_listener" "default" {
-  load_balancer_arn = aws_alb.default.id
+resource "aws_lb_listener" "default" {
+  load_balancer_arn = aws_lb.default.id
   port              = "80"
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = aws_alb_target_group.default.id
+    target_group_arn = aws_lb_target_group.default.id
     type             = "forward"
   }
 }

--- a/terraform/ecs_service_app.tf
+++ b/terraform/ecs_service_app.tf
@@ -28,7 +28,7 @@ resource "aws_ecs_service" "default" {
     assign_public_ip = true # not ideal, but to help avoid paying for a NAT gateway
   }
 
-  depends_on = [aws_alb.default]
+  depends_on = [aws_lb.default]
 
   # java app can take ~100 seconds to start up with
   # current memory settings
@@ -36,7 +36,7 @@ resource "aws_ecs_service" "default" {
   health_check_grace_period_seconds = 300
 
   load_balancer {
-    target_group_arn = aws_alb_target_group.default.arn
+    target_group_arn = aws_lb_target_group.default.arn
     container_name   = "hello-ecs"
     container_port   = 8080
   }
@@ -113,7 +113,7 @@ resource "aws_appautoscaling_policy" "app" {
 
     predefined_metric_specification {
       predefined_metric_type = "ALBRequestCountPerTarget"
-      resource_label         = "${aws_alb.default.arn_suffix}/${aws_alb_target_group.default.arn_suffix}"
+      resource_label         = "${aws_lb.default.arn_suffix}/${aws_lb_target_group.default.arn_suffix}"
     }
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,3 @@
 output "alb" {
-  value = "http://${aws_alb.default.dns_name}"
+  value = "http://${aws_lb.default.dns_name}"
 }


### PR DESCRIPTION
Updated all Terraform resources from the deprecated aws_alb_* naming to the current standard aws_lb_* naming convention. The aws_lb resources are the recommended approach and support both Application and Network Load Balancers.

Changes:
- aws_alb → aws_lb
- aws_alb_target_group → aws_lb_target_group
- aws_alb_listener → aws_lb_listener
- Updated all references across terraform/alb.tf, terraform/ecs_service_app.tf, and terraform/outputs.tf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to use current AWS Load Balancer resource naming conventions, replacing deprecated naming format for improved maintainability and consistency with AWS best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->