### PR TITLE
Clean up Makefile

- Remove obsolete TODO comments
- Use := with $(shell) for TAG definition (better performance)
- Add .PHONY declarations for non-file targets
- Use @echo for cleaner output (suppress command echoing)
- Remove unused test target placeholder

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -1,16 +1,14 @@
-# TODO: fix date logic; avoid regen
-#TAG = `date "+%Y%m%d-%H%M"`-`git rev-parse --short HEAD`
-TAG = `git rev-parse --short HEAD`
+# Define image tag using git commit hash
+TAG := $(shell git rev-parse --short HEAD)
+
+.PHONY: build deploy
 
 build:
 	docker build -t hello-ecs:$(TAG) .
 	docker tag hello-ecs:$(TAG) ericdahl/hello-ecs:latest
 	docker tag hello-ecs:$(TAG) ericdahl/hello-ecs:$(TAG)
-	echo "Built hello-ecs:$(TAG)"
+	@echo "Built hello-ecs:$(TAG)"
 
 deploy: build
 	docker push ericdahl/hello-ecs:$(TAG)
-	echo "Pushed ericdahl/hello-ecs:$(TAG)"
-
-test:
-	echo $(C)
+	@echo "Pushed ericdahl/hello-ecs:$(TAG)"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration and streamlined build and deployment workflow handling.
  * Removed obsolete build target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->