### PR TITLE
fix: scope ecs task execution IAM policy

### DIFF
--- a/terraform/iam_ecs_app_task_execution.tf
+++ b/terraform/iam_ecs_app_task_execution.tf
@@ -18,14 +18,13 @@ data "aws_iam_policy_document" "ecs_assume_role_policy" {
 data "aws_iam_policy_document" "ecs_task_execution_policy" {
   statement {
     actions = [
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
       "logs:CreateLogStream",
       "logs:PutLogEvents"
     ]
-    resources = ["*"]
+
+    resources = [
+      "${aws_cloudwatch_log_group.app.arn}:*"
+    ]
   }
 }
 


### PR DESCRIPTION
## Summary

Scopes the ECS task execution IAM policy down to only the CloudWatch Logs resources this task actually needs, and removes unnecessary ECR permissions.

## Changes

- removed ECR permissions from the ECS task execution role
- scoped CloudWatch Logs permissions to `${aws_cloudwatch_log_group.app.arn}:*`
- kept the change focused to the task execution policy only

## Testing

- reviewed the Terraform references to confirm the task uses Docker Hub, not ECR
- attempted to run `terraform validate`, but Terraform is not installed in this environment

Fixes ericdahl/hello-ecs#10