### PR TITLE
refactor: use standalone vpc security group rule resources

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -30,24 +30,18 @@ resource "aws_security_group" "alb" {
   name   = "${local.name}-alb"
 }
 
-resource "aws_security_group_rule" "alb_ingress_http_all" {
+resource "aws_vpc_security_group_ingress_rule" "alb_ingress_http_all" {
   security_group_id = aws_security_group.alb.id
-
-  type      = "ingress"
-  protocol  = "tcp"
-  from_port = 80
-  to_port   = 80
-
-  cidr_blocks = ["0.0.0.0/0"]
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 80
+  ip_protocol       = "tcp"
+  to_port           = 80
 }
 
-resource "aws_security_group_rule" "alb_egress_http_app" {
-  security_group_id = aws_security_group.alb.id
-
-  type      = "egress"
-  protocol  = "tcp"
-  from_port = 8080
-  to_port   = 8080
-
-  source_security_group_id = aws_security_group.ecs_task.id
+resource "aws_vpc_security_group_egress_rule" "alb_egress_http_app" {
+  security_group_id            = aws_security_group.alb.id
+  referenced_security_group_id = aws_security_group.ecs_task.id
+  from_port                    = 8080
+  ip_protocol                  = "tcp"
+  to_port                      = 8080
 }

--- a/terraform/ecs_service_app.tf
+++ b/terraform/ecs_service_app.tf
@@ -47,45 +47,29 @@ resource "aws_security_group" "ecs_task" {
   vpc_id = aws_vpc.main.id
 }
 
-resource "aws_security_group_rule" "ecs_task_ingress_alb" {
-  security_group_id = aws_security_group.ecs_task.id
-
-  type      = "ingress"
-  protocol  = "tcp"
-  from_port = 8080
-  to_port   = 8080
-
-  source_security_group_id = aws_security_group.alb.id
-
-  description = "allows ALB to make requests to ECS Task"
+resource "aws_vpc_security_group_ingress_rule" "ecs_task_ingress_alb" {
+  security_group_id            = aws_security_group.ecs_task.id
+  referenced_security_group_id = aws_security_group.alb.id
+  from_port                    = 8080
+  to_port                      = 8080
+  ip_protocol                  = "tcp"
+  description                  = "allows ALB to make requests to ECS Task"
 }
 
-resource "aws_security_group_rule" "ecs_task_ingress_admin" {
+resource "aws_vpc_security_group_ingress_rule" "ecs_task_ingress_admin" {
   security_group_id = aws_security_group.ecs_task.id
-
-  type      = "ingress"
-  protocol  = "tcp"
-  from_port = 8080
-  to_port   = 8080
-
-  cidr_blocks = [var.admin_cidr_ingress]
-
-  description = "allow connections to ECS tasks from admin cidr for debugging"
+  cidr_ipv4         = var.admin_cidr_ingress
+  from_port         = 8080
+  to_port           = 8080
+  ip_protocol       = "tcp"
+  description       = "allow connections to ECS tasks from admin cidr for debugging"
 }
 
-
-
-resource "aws_security_group_rule" "ecs_task_egress_all" {
+resource "aws_vpc_security_group_egress_rule" "ecs_task_egress_all" {
   security_group_id = aws_security_group.ecs_task.id
-
-  type     = "egress"
-  protocol = "-1"
-
-  from_port = 0
-  to_port   = 0
-
-  cidr_blocks = ["0.0.0.0/0"]
-  description = "allows ECS task to make egress calls"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+  description       = "allows ECS task to make egress calls"
 }
 
 resource "aws_cloudwatch_log_group" "app" {

--- a/terraform/elasticache.tf
+++ b/terraform/elasticache.tf
@@ -19,27 +19,20 @@ resource "aws_security_group" "elasticache_sg" {
   name   = "${local.name}-elasticache"
 }
 
-resource "aws_security_group_rule" "elasticache_ingress_ecs" {
-  security_group_id = aws_security_group.elasticache_sg.id
-
-  type      = "ingress"
-  protocol  = "tcp"
-  from_port = 6379
-  to_port   = 6379
-
-  source_security_group_id = aws_security_group.ecs_task.id
-  description              = "allows ECS Task to make connections to redis"
+resource "aws_vpc_security_group_ingress_rule" "elasticache_ingress_ecs" {
+  security_group_id            = aws_security_group.elasticache_sg.id
+  referenced_security_group_id = aws_security_group.ecs_task.id
+  from_port                    = 6379
+  to_port                      = 6379
+  ip_protocol                  = "tcp"
+  description                  = "allows ECS Task to make connections to redis"
 }
 
-resource "aws_security_group_rule" "elasticache_ingress_admin" {
+resource "aws_vpc_security_group_ingress_rule" "elasticache_ingress_admin" {
   security_group_id = aws_security_group.ecs_task.id
-
-  from_port = 6379
-  protocol  = "tcp"
-  to_port   = 6379
-  type      = "ingress"
-
-  cidr_blocks = [var.admin_cidr_ingress]
-  description = "allows admin to connect to redis"
+  cidr_ipv4         = var.admin_cidr_ingress
+  from_port         = 6379
+  to_port           = 6379
+  ip_protocol       = "tcp"
+  description       = "allows admin to connect to redis"
 }
-


### PR DESCRIPTION
## Summary

Refactors the security group rules to use the modern standalone `aws_vpc_security_group_ingress_rule` and `aws_vpc_security_group_egress_rule` resources while preserving the existing rule behavior.

## Changes

- replaced `aws_security_group_rule` resources in `terraform/alb.tf`
- replaced `aws_security_group_rule` resources in `terraform/ecs_service_app.tf`
- replaced `aws_security_group_rule` resources in `terraform/elasticache.tf`
- left the `aws_security_group` resources themselves in place

## Testing

- reviewed the refactor to keep the same ports, CIDRs, descriptions, and security-group references
- verified the old `aws_security_group_rule` resources are no longer referenced in `terraform/`
- could not run `terraform validate` here because Terraform is not installed in this environment

Fixes ericdahl/hello-ecs#14