### PR TITLE
Rename VPC route table, IGW, and association to descriptive names

### DIFF
--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -14,21 +14,21 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch = true
 }
 
-resource "aws_internet_gateway" "gw" {
+resource "aws_internet_gateway" "main" {
   vpc_id = aws_vpc.main.id
 }
 
-resource "aws_route_table" "r" {
+resource "aws_route_table" "public" {
   vpc_id = aws_vpc.main.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.gw.id
+    gateway_id = aws_internet_gateway.main.id
   }
 }
 
-resource "aws_route_table_association" "a" {
+resource "aws_route_table_association" "public" {
   count          = var.az_count
   subnet_id      = aws_subnet.public[count.index].id
-  route_table_id = aws_route_table.r.id
+  route_table_id = aws_route_table.public.id
 }


### PR DESCRIPTION
## Summary

- Rename `aws_internet_gateway.gw` → `aws_internet_gateway.main`
- Rename `aws_route_table.r` → `aws_route_table.public`
- Rename `aws_route_table_association.a` → `aws_route_table_association.public`

Improves readability by replacing single-letter/generic names with descriptive ones that reflect the role of each resource.

> **Note:** These are Terraform state renames. Running `terraform apply` after this change will require `terraform state mv` commands (or `moved` blocks) to avoid resource recreation.

https://claude.ai/code/session_01SnT5FDzGK3Ff86f69hcv2k